### PR TITLE
fix(actor): ensure onCrash is called for a stateless actor given an async func.

### DIFF
--- a/@nact/core/actor.test.ts
+++ b/@nact/core/actor.test.ts
@@ -852,12 +852,26 @@ describe('Actor', function () {
     });
 
     it('should be executed for a stateless actor', async function() {
-      const mockCrash = jest.fn((msg: any, _err: any, ctx: SupervisionContext<any, any>) => { 
-        dispatch(msg.sender, { error: 'we crashed' }); 
-        return ctx.resume; 
+      const mockCrash = jest.fn((msg: any, _err: any, ctx: SupervisionContext<any, any>) => {
+        dispatch(msg.sender, { error: 'we crashed' });
+        return ctx.resume;
       });
 
       const crashingActor = spawnStateless(system, (_) => {
+        throw new Error("it's crash o'clock");
+      }, { name: 'crashyboi', onCrash: mockCrash });
+
+      await query(crashingActor, ref => ({ sender: ref }), 5000);
+      expect(mockCrash.mock.calls.length).toBe(1);
+    });
+
+    it('should be executed for a stateless actor with async function', async function() {
+      const mockCrash = jest.fn((msg: any, _err: any, ctx: SupervisionContext<any, any>) => {
+        dispatch(msg.sender, { error: 'we crashed' });
+        return ctx.resume;
+      });
+
+      const crashingActor = spawnStateless(system, async (_) => {
         throw new Error("it's crash o'clock");
       }, { name: 'crashyboi', onCrash: mockCrash });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This wraps the async execution in stateless actor in an error handler to pass it to handleFault while still allowing functions to be executed in parallel.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a stateless actor is spawned with an async function and an error occurs within the function, it is not caught by the handleFault code, but instead crashes the process nact is running in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
