### PR TITLE
Contravariant Msg type in Dispatchable and LocalActorRef

### DIFF
--- a/@nact/core/actor.test.ts
+++ b/@nact/core/actor.test.ts
@@ -3,7 +3,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { SupervisionContext } from './actor';
-import { start, spawn, spawnStateless, dispatch, stop, query, milliseconds, ActorContext, applyOrThrowIfStopped } from './index';
+import { ActorContext, applyOrThrowIfStopped, dispatch, milliseconds, query, spawn, spawnStateless, start, stop } from './index';
 import { LocalActorRef, LocalActorSystemRef, nobody } from './references';
 
 chai.use(chaiAsPromised);
@@ -58,6 +58,17 @@ describe('LocalActorRef', function () {
     let grandchild = spawnStateless(child, ignore);
     child.path.system!.should.equal(system.path.system);
     grandchild.path.parts.slice(0, child.path.parts.length - 2).should.deep.equal(child.path.parts);
+  });
+
+  it('should be contravariant to message type', function () {
+    let actor: LocalActorRef<string | number> = spawnStateless(system, (_msg: string | number) => {});
+
+    let smallerActor: LocalActorRef<string> = actor;
+    dispatch(smallerActor, "a");
+
+    // @ts-expect-error
+    let biggerActor: LocalActorRef<string | number | symbol> = actor;
+    dispatch(biggerActor, "a");
   });
 });
 

--- a/@nact/core/actor.ts
+++ b/@nact/core/actor.ts
@@ -1,13 +1,13 @@
-import { ActorSystemRef, localActorRef, LocalActorRef, LocalActorSystemRef, localTemporaryRef } from "./references";
+import { Milliseconds } from ".";
+import assert from './assert';
 import { Deferral } from './deferral';
+import { ICanAssertNotStopped, ICanDispatch, ICanHandleFault, ICanManageTempReferences, ICanQuery, ICanReset, ICanStop, IHaveChildren, IHaveName, InferResponseFromMsgFactory, QueryMsgFactory } from "./interfaces";
+import { addMacrotask, clearMacrotask } from './macrotask';
+import { ActorPath } from "./paths";
+import { ActorSystemRef, localActorRef, LocalActorRef, LocalActorSystemRef, localTemporaryRef } from "./references";
+import { defaultSupervisionPolicy, SupervisionActions } from './supervision';
 import { applyOrThrowIfStopped, find } from './system-map';
 import Queue from './vendored/denque';
-import assert from './assert';
-import { defaultSupervisionPolicy, SupervisionActions } from './supervision';
-import { ActorPath } from "./paths";
-import { Milliseconds } from ".";
-import { addMacrotask, clearMacrotask } from './macrotask'
-import { ICanAssertNotStopped, ICanDispatch, ICanHandleFault, ICanManageTempReferences, ICanQuery, ICanReset, ICanStop, IHaveChildren, IHaveName, InferResponseFromMsgFactory, QueryMsgFactory } from "./interfaces";
 
 function unit(): void { };
 
@@ -360,17 +360,17 @@ export type ActorProps<State, Msg, ParentRef extends ActorSystemRef | LocalActor
   afterStop?: (state: State, ctx: ActorContext<Msg, ParentRef>) => void | Promise<void>
 };
 
-export type StatelessActorProps<ParentRef extends ActorSystemRef | LocalActorRef<any>> = {
+export type StatelessActorProps<Msg, ParentRef extends ActorSystemRef | LocalActorRef<any>> = {
   name?: string,
   shutdownAfter?: Milliseconds,
-  onCrash?: SupervisionActorFunc<InferMsgFromStatelessFunc<any>, ParentRef>,
+  onCrash?: SupervisionActorFunc<Msg, ParentRef>,
 };
 
 
 export function spawn<ParentRef extends LocalActorSystemRef | LocalActorRef<any>, Func extends ActorFunc<any, any, ParentRef>>(
   parent: ParentRef,
   f: Func,
-  properties?: ActorProps<InferStateFromFunc<Func>, InferMsgFromFunc<Func>, ParentRef> | StatelessActorProps<ParentRef>
+  properties?: ActorProps<InferStateFromFunc<Func>, InferMsgFromFunc<Func>, ParentRef> | StatelessActorProps<InferMsgFromFunc<Func>, ParentRef>
 ): LocalActorRef<InferMsgFromFunc<Func>> {
   return applyOrThrowIfStopped(
     parent,
@@ -390,7 +390,7 @@ const statelessSupervisionPolicy = (_: unknown, __: unknown, ctx: SupervisionCon
 export function spawnStateless<ParentRef extends LocalActorSystemRef | LocalActorRef<any>, Func extends StatelessActorFunc<any, ParentRef>>(
   parent: ParentRef,
   f: Func,
-  propertiesOrName?: StatelessActorProps<ParentRef>
+  propertiesOrName?: StatelessActorProps<InferMsgFromStatelessFunc<Func>, ParentRef>
 ): LocalActorRef<InferMsgFromStatelessFunc<Func>> {
   return spawn(
     parent,

--- a/@nact/core/functions.test.ts
+++ b/@nact/core/functions.test.ts
@@ -1,0 +1,100 @@
+import { spawnStateless } from ".";
+import { dispatch, query } from "./functions";
+import { start, stop } from "./index";
+import { Dispatchable, LocalActorRef, LocalActorSystemRef } from "./references";
+
+describe("query", function () {
+  let system: LocalActorSystemRef;
+  beforeEach(() => {
+    system = start();
+  });
+  afterEach(() => stop(system));
+
+  it("should accept only supported messages", function () {
+    let actor = spawnStateless(
+      system,
+      (msg: {
+        readonly sender: Dispatchable<string | number>;
+        readonly valueToDouble: string | number;
+      }) => {
+        const doubledValued =
+          typeof msg.valueToDouble === "string"
+            ? msg.valueToDouble + msg.valueToDouble
+            : msg.valueToDouble + msg.valueToDouble;
+        dispatch(msg.sender, doubledValued);
+      }
+    );
+
+    query(actor, (x) => ({ sender: x, valueToDouble: 10 }), 30);
+    query(actor, (x) => ({ sender: x, valueToDouble: "ten" }), 30);
+    // @ts-expect-error
+    query(actor, (x) => ({ sender: x, valueToDouble: null }), 30);
+  });
+
+  it("should accept only known supported messages even with no upper bound on supported message types", function () {
+    let scopeThatUsesSmallerActor = <
+      TActor extends LocalActorRef<{
+        sender: Dispatchable<string | number>;
+        valueToDouble: string | number;
+      }>
+    >(
+      actor: TActor
+    ) => {
+      query(actor, (x) => ({ sender: x, valueToDouble: 10 }), 30);
+      query(actor, (x) => ({ sender: x, valueToDouble: "ten" }), 30);
+      // @ts-expect-error
+      query(actor, (x) => ({ sender: x, valueToDouble: null }), 30);
+    };
+
+    let actor = spawnStateless(
+      system,
+      (msg: {
+        readonly sender: Dispatchable<string | number>;
+        readonly valueToDouble: string | number;
+      }) => {
+        const doubledValued =
+          typeof msg.valueToDouble === "string"
+            ? msg.valueToDouble + msg.valueToDouble
+            : msg.valueToDouble + msg.valueToDouble;
+        dispatch(msg.sender, doubledValued);
+      }
+    );
+    scopeThatUsesSmallerActor(actor);
+  });
+});
+
+describe("dispatch", function () {
+  let system: LocalActorSystemRef;
+  beforeEach(() => {
+    system = start();
+  });
+  afterEach(() => stop(system));
+
+  it("should accept only supported messages", function () {
+    let actor = spawnStateless(system, (_msg: string | number) => {});
+
+    dispatch(actor, "text");
+    dispatch(actor, 1000);
+    // @ts-expect-error
+    dispatch(actor, null);
+  });
+
+  it("should accept only known supported messages even with no upper bound on supported message types", function () {
+    let scopeThatUsesSmallerActor = <
+      TActor extends LocalActorRef<string | number>
+    >(
+      actor: TActor
+    ) => {
+      dispatch(actor, "text");
+      dispatch(actor, 1000);
+      // @ts-expect-error
+      dispatch(actor, null);
+    };
+
+    let biggerActor: LocalActorRef<string | number | symbol> = spawnStateless(
+      system,
+      (_msg: string | number | symbol) => {}
+    );
+    scopeThatUsesSmallerActor(biggerActor);
+  });
+});

--- a/@nact/core/functions.ts
+++ b/@nact/core/functions.ts
@@ -1,7 +1,7 @@
-import { Dispatchable, Stoppable } from "./references";
-import { Milliseconds } from "./time";
-import { find } from './system-map';
 import { ICanDispatch, ICanQuery, ICanStop } from "./interfaces";
+import { Dispatchable, Stoppable } from "./references";
+import { find } from './system-map';
+import { Milliseconds } from "./time";
 
 export function stop(actor: Stoppable) {
   let concreteActor = find<ICanStop>(actor);
@@ -15,7 +15,7 @@ export type QueryMsgFactory<Req, Res> = (tempRef: Dispatchable<Res>) => Req;
 export type InferResponseFromMsgFactory<T extends QueryMsgFactory<any, any>> = T extends QueryMsgFactory<infer _Req, infer Res> ? Res : never;
 type Maybe<T> = Partial<T>;
 
-export function query<ActorRef extends Dispatchable<any>, MsgFactory extends QueryMsgFactory<ActorRef extends Dispatchable<infer Msg> ? Msg : never, any>>(actor: ActorRef, queryFactory: MsgFactory, timeout: Milliseconds):
+export function query<Msg, MsgFactory extends QueryMsgFactory<Msg, any>>(actor: Dispatchable<Msg>, queryFactory: MsgFactory, timeout: Milliseconds):
   Promise<InferResponseFromMsgFactory<MsgFactory>> {
   if (!timeout) {
     throw new Error('A timeout is required to be specified');
@@ -28,9 +28,7 @@ export function query<ActorRef extends Dispatchable<any>, MsgFactory extends Que
     : Promise.reject(new Error('Actor stopped or never existed. Query can never resolve'));
 };
 
-export function dispatch<ActorRef extends Dispatchable<any>>(actor: ActorRef, msg: ActorRef extends Dispatchable<infer Msg> ? Msg : never): void {
-  let concreteActor = find<ICanDispatch<ActorRef>>(actor);
-  concreteActor &&
-    concreteActor.dispatch &&
-    concreteActor.dispatch(msg);
-};
+export function dispatch<Msg>(actor: Dispatchable<Msg>, msg: Msg): void {
+  let concreteActor = find<ICanDispatch<Msg>>(actor);
+  concreteActor && concreteActor.dispatch && concreteActor.dispatch(msg);
+}

--- a/@nact/core/references.ts
+++ b/@nact/core/references.ts
@@ -9,7 +9,7 @@ enum DispatchableMarker {
 }
 
 export type Dispatchable<Msg> =
-  { __dispatch__: DispatchableMarker, protocol: Msg } & Ref;
+  { __dispatch__: DispatchableMarker, protocol: (msg: Msg) => void } & Ref;
 
 enum StoppableMarker {
   _ = ""


### PR DESCRIPTION
Makes LocalActorRef and Dispatchable contravariant.

## Description
The type of the protocol field of Dispatchable was changed to a type that TypeScript recognizes as contravariant. This field doesn't seem to be used for anything else beside coaxing the type system. Please deny the PR if this assumption is wrong.

Fixing this surfaced an error related to the fact that StatelessActorProps was not exactly assignable to ActorProps, even though it probably should be. I fixed this as well.

Some changes to the types of dispatch and query functions were also necessary for them to work with new behavior of Dispatchable and LocalActorRef.

## Related Issue
Fixes #147 

## Motivation and Context
The error, as outlined in the #147, causes the type system to disallow certain assigning statements that should be allowed and vice versa.

## How Has This Been Tested?
- Wrote a new unit test in actor.test.ts that creates a scenario where the contravariance of LocalActorRef is put to the test.
  - It makes use of // ts-expect-error
  - Is part of the `npm run typecheck`, not `npm run test`
- Wrote a new unit test suite – functions.test.ts  – for dispatch and query, only testing types.
  - It makes use of // ts-expect-error
  - Is part of the `npm run typecheck`, not `npm run test`
- Ran `npm run test` in @nact/core
- Ran `npm run typecheck` in @nact/core

## Screenshots (if appropriate):
The new test case I wrote went from this:
![image](https://github.com/user-attachments/assets/5c89efaa-c97e-4f93-aaf5-dbdd47d9e104)

to this:
![image](https://github.com/user-attachments/assets/abc7c979-4da8-4e2d-8e7f-70347f4dc2b8)

There's also more test cases in functions.test.ts that now pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

~I guess the interface for StatelessActorProps was changed slightly, so if this is actually used in explicit form anywhere. Like a field like this, `let actorProps: StatelessActorProps<LocalActorSystemRef> = ...`, that line will fail. I find that it was basically a bug that the line would be accepted anyway because there is no such signature for ActorProps (one without State and Msg). However, with the logic that existing code that would work now would end up not compiling, it could be classified as a breaking change.~

EDIT: Fixing of some edge case type logic has entailed changes to the types of dispatch and query as well as the original StatelessActorProps. It is hard to argue that this PR is anything other than a breaking change at this point.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (I assume this has been renamed to CODE_OF_CONDUCT).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
